### PR TITLE
Add extern 'C' to prevent name mangling in C++ compilation (Fix issue #2)

### DIFF
--- a/src/book.h
+++ b/src/book.h
@@ -1,6 +1,10 @@
 #ifndef BOOK_H_INCLUDED
 #define BOOK_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
 struct Book {
     char name[50];
     char author[50];
@@ -9,5 +13,9 @@ struct Book {
     char isbn[14]; // Officially it requires 13 and the '\0' character at the end.
     struct Book* next;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BOOK_H_INCLUDED */

--- a/src/library.h
+++ b/src/library.h
@@ -1,6 +1,10 @@
 #ifndef LIBRARY_H_INCLUDED
 #define LIBRARY_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "book.h"
 
 // Works as a linked list to store books.
@@ -19,5 +23,9 @@ void delete_book(struct Library* lib, const char* isbn);
 void show_library(struct Library* lib);
 
 void free_memory(struct Library* lib);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBRARY_H_INCLUDED */


### PR DESCRIPTION
This pull request adds extern "C" declarations to prevent name mangling when compiling the code with a C++ compiler. This ensures that function names remain unchanged and can be correctly linked with C code. This fixes issue #2.